### PR TITLE
fix: NextJS 12 Error

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const ammendOneOfRules = config => (a, c) => {
 		&& c.test.source
 
 	const matchesRegExpIssuer = 'issuer' in c
+		&& typeof c.issuer !== 'undefined'
 		&& c.issuer instanceof RegExp
 		&& c.issuer.source
 
@@ -43,12 +44,14 @@ const ammendOneOfRules = config => (a, c) => {
 		|| (() => false))
 
 	const issuerAccepts = ('issuer' in c
+		&& typeof c.issuer !== 'undefined'
 		&& 'and' in c.issuer
 		&& Array.isArray(c.issuer.and)
 		&& matchArray(c.issuer.and)
 		|| (() => false))
 
 	const issuerAvoids = ('issuer' in c
+		&& typeof c.issuer !== 'undefined'
 		&& 'not' in c.issuer
 		&& Array.isArray(c.issuer.not)
 		&& matchArray(c.issuer.not)


### PR DESCRIPTION
With NextJS 12 there is an error when we start the dev server with the plugin

```
TypeError: Cannot use 'in' operator to search for 'not' in undefined
    at /home/avior/projects/documentation/node_modules/next-pre-css/index.js:54:12
    at Array.reduce (<anonymous>)
    at /home/avior/projects/documentation/node_modules/next-pre-css/index.js:108:36
    at Array.map (<anonymous>)
    at Object.webpack (/home/avior/projects/documentation/node_modules/next-pre-css/index.js:107:37)
    at Object.getBaseWebpackConfig [as default] (/home/avior/projects/documentation/node_modules/next/dist/build/webpack-config.js:1238:32)
    at async Promise.all (index 0)
    at async Span.traceAsyncFn (/home/avior/projects/documentation/node_modules/next/dist/trace/trace.js:79:20)
    at async Span.traceAsyncFn (/home/avior/projects/documentation/node_modules/next/dist/trace/trace.js:79:20)
    at async HotReloader.start (/home/avior/projects/documentation/node_modules/next/dist/server/dev/hot-reloader.js:328:30)
```

I fixed it by adding checks to see if the value is undefined or not